### PR TITLE
Fixed send err because of wrong state 'connecting'

### DIFF
--- a/public/js/websocket.js
+++ b/public/js/websocket.js
@@ -56,6 +56,7 @@ Bgpio.WebSocket.error = function(evt) {
 };
 
 Bgpio.WebSocket.sendCode = function(codeStr) {
-  Bgpio.WebSocket.send(
-      JSON.stringify({'content': 'python_code', 'code': codeStr}));
+  var payload = JSON.stringify({'content': 'python_code', 'code': codeStr})
+  if (Bgpio.DEBUG) console.log('payload: ' + payload + '\n');
+  Bgpio.WebSocket.ws.onopen = () => Bgpio.WebSocket.send(payload);
 };


### PR DESCRIPTION
I wasn't able to send the content to the python script because the connection was always in the wrong state 'connecting'. So, I delayed it a bit.